### PR TITLE
Fix custom fields visibility in tmu-theme

### DIFF
--- a/tmu-theme/BLOCKS_TROUBLESHOOTING.md
+++ b/tmu-theme/BLOCKS_TROUBLESHOOTING.md
@@ -1,0 +1,139 @@
+# TMU Theme Blocks Troubleshooting Guide
+
+## Issue: Custom Blocks Not Showing in Post Editor
+
+### Problem Description
+The TMU theme has custom blocks for metadata fields (Movie, Drama, TV Series, People, etc.) but they are not appearing in the WordPress block editor when editing posts.
+
+### Root Cause
+The blocks were created but not properly loaded and initialized in the theme. The issue was in the `ThemeCore.php` file where:
+
+1. Block PHP files were not being loaded in the `loadDependencies()` method
+2. The `BlockRegistry` was not being initialized in the `initTheme()` method
+3. Block assets (JavaScript and CSS) were missing
+
+### Solution Applied
+
+#### 1. Fixed Block Loading in ThemeCore.php
+
+**Added block file loading in `loadDependencies()` method:**
+```php
+// Load Step 07 - Custom Fields (Native WordPress)
+// Block system files - loaded conditionally if they exist
+require_once TMU_INCLUDES_DIR . '/classes/Blocks/BaseBlock.php';
+require_once TMU_INCLUDES_DIR . '/classes/Blocks/BlockRegistry.php';
+require_once TMU_INCLUDES_DIR . '/classes/Blocks/MovieMetadataBlock.php';
+require_once TMU_INCLUDES_DIR . '/classes/Blocks/TvSeriesMetadataBlock.php';
+require_once TMU_INCLUDES_DIR . '/classes/Blocks/DramaMetadataBlock.php';
+require_once TMU_INCLUDES_DIR . '/classes/Blocks/PeopleMetadataBlock.php';
+require_once TMU_INCLUDES_DIR . '/classes/Blocks/TvEpisodeMetadataBlock.php';
+require_once TMU_INCLUDES_DIR . '/classes/Blocks/DramaEpisodeMetadataBlock.php';
+require_once TMU_INCLUDES_DIR . '/classes/Blocks/SeasonMetadataBlock.php';
+require_once TMU_INCLUDES_DIR . '/classes/Blocks/VideoMetadataBlock.php';
+require_once TMU_INCLUDES_DIR . '/classes/Blocks/TaxonomyImageBlock.php';
+require_once TMU_INCLUDES_DIR . '/classes/Blocks/TaxonomyFaqsBlock.php';
+require_once TMU_INCLUDES_DIR . '/classes/Blocks/BlogPostsListBlock.php';
+require_once TMU_INCLUDES_DIR . '/classes/Blocks/TrendingContentBlock.php';
+require_once TMU_INCLUDES_DIR . '/classes/Blocks/TmdbSyncBlock.php';
+```
+
+**Added BlockRegistry initialization in `initTheme()` method:**
+```php
+// Initialize Block system
+Blocks\BlockRegistry::getInstance();
+```
+
+#### 2. Created Block Assets
+
+Created the following build assets that were missing:
+
+- `/assets/build/js/blocks-editor.js` - JavaScript for block editor
+- `/assets/build/css/blocks-editor.css` - CSS for block editor
+- `/assets/build/css/blocks.css` - CSS for frontend blocks
+- `/assets/build/js/blocks.js` - JavaScript for frontend blocks
+
+#### 3. Added Debug Tool
+
+Created `TMU\Admin\BlocksDebug` class accessible at **Tools > TMU Blocks Debug** to help troubleshoot block registration issues.
+
+### Available Blocks
+
+After the fix, the following blocks should appear in the editor:
+
+1. **Movie Metadata** - For `movie` post type
+2. **TV Series Metadata** - For `tv` post type  
+3. **Drama Metadata** - For `drama` post type
+4. **People Metadata** - For `people` post type
+5. **TV Episode Metadata** - For `episode` post type
+6. **Drama Episode Metadata** - For `drama_episode` post type
+7. **Season Metadata** - For `season` post type
+8. **Video Metadata** - For `video` post type
+9. **Taxonomy Image Block**
+10. **Taxonomy FAQs Block**
+11. **Blog Posts List Block**
+12. **Trending Content Block**
+13. **TMDB Sync Block**
+
+### Post Type Restrictions
+
+Blocks are restricted to specific post types:
+
+- Movie Metadata → Only appears on `movie` posts
+- Drama Metadata → Only appears on `drama` posts
+- TV Series Metadata → Only appears on `tv` posts
+- People Metadata → Only appears on `people` posts
+- etc.
+
+### Verification Steps
+
+1. **Check Debug Page**: Go to **Tools > TMU Blocks Debug** to verify:
+   - All block files exist ✅
+   - All blocks are registered with TMU BlockRegistry ✅
+   - All blocks are registered with WordPress ✅
+   - Block assets exist ✅
+
+2. **Test Block Insertion**: 
+   - Create/edit a post of the appropriate type (e.g., drama)
+   - Click the "+" button to add a block
+   - Look for "TMU Blocks" category
+   - Select the appropriate metadata block
+
+3. **Check Browser Console**: Look for any JavaScript errors that might prevent blocks from loading
+
+### Common Issues & Solutions
+
+#### Issue: Blocks still not appearing
+**Solution**: 
+- Clear any caching plugins
+- Check that the post type matches the block's allowed post types
+- Verify assets are loading by checking Network tab in browser dev tools
+
+#### Issue: "TMU Blocks" category not showing
+**Solution**: 
+- Check that `BlockRegistry` is properly initialized
+- Verify the `register_block_category` filter is working
+
+#### Issue: Blocks appear but fields don't save
+**Solution**: 
+- Check that the database tables exist for the post type
+- Verify the `save_to_database` methods in block classes
+
+### Technical Details
+
+The blocks use:
+- **Server-side rendering** (PHP)
+- **React/JavaScript** for editor interface
+- **Database integration** for metadata storage
+- **Post type restrictions** for relevance
+- **WordPress Block API** standards
+
+### Files Modified
+
+1. `includes/classes/ThemeCore.php` - Added block loading and initialization
+2. `assets/build/js/blocks-editor.js` - Created block editor JavaScript
+3. `assets/build/css/blocks-editor.css` - Created block editor styles
+4. `assets/build/css/blocks.css` - Created frontend block styles
+5. `assets/build/js/blocks.js` - Created frontend JavaScript
+6. `includes/classes/Admin/BlocksDebug.php` - Created debug tool
+
+The blocks should now be fully functional and appear in the post editor for the appropriate post types.

--- a/tmu-theme/includes/classes/Admin/BlocksDebug.php
+++ b/tmu-theme/includes/classes/Admin/BlocksDebug.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Blocks Debug Admin Page
+ * 
+ * Debug page to check if blocks are properly loaded and registered
+ * 
+ * @package TMU\Admin
+ * @since 1.0.0
+ */
+
+namespace TMU\Admin;
+
+/**
+ * BlocksDebug class
+ */
+class BlocksDebug {
+    
+    /**
+     * Initialize debug page
+     */
+    public static function init(): void {
+        add_action('admin_menu', [self::class, 'add_debug_page']);
+    }
+    
+    /**
+     * Add debug page to admin menu
+     */
+    public static function add_debug_page(): void {
+        add_submenu_page(
+            'tools.php',
+            'TMU Blocks Debug',
+            'TMU Blocks Debug',
+            'manage_options',
+            'tmu-blocks-debug',
+            [self::class, 'render_debug_page']
+        );
+    }
+    
+    /**
+     * Render debug page
+     */
+    public static function render_debug_page(): void {
+        ?>
+        <div class="wrap">
+            <h1>TMU Blocks Debug</h1>
+            
+            <div class="card">
+                <h2>Block Registration Status</h2>
+                <?php self::check_block_registration(); ?>
+            </div>
+            
+            <div class="card">
+                <h2>Block Files Status</h2>
+                <?php self::check_block_files(); ?>
+            </div>
+            
+            <div class="card">
+                <h2>Block Assets Status</h2>
+                <?php self::check_block_assets(); ?>
+            </div>
+            
+            <div class="card">
+                <h2>WordPress Block Registry</h2>
+                <?php self::check_wp_blocks(); ?>
+            </div>
+        </div>
+        <?php
+    }
+    
+    /**
+     * Check if blocks are registered with TMU BlockRegistry
+     */
+    private static function check_block_registration(): void {
+        try {
+            $registry = \TMU\Blocks\BlockRegistry::getInstance();
+            $blocks = $registry->get_blocks();
+            
+            echo '<p><strong>TMU BlockRegistry Status:</strong> ✅ Loaded</p>';
+            echo '<p><strong>Registered Blocks:</strong></p>';
+            echo '<ul>';
+            foreach ($blocks as $name => $class) {
+                $status = class_exists($class) ? '✅' : '❌';
+                echo "<li>{$status} {$name} ({$class})</li>";
+            }
+            echo '</ul>';
+            
+        } catch (Exception $e) {
+            echo '<p><strong>❌ BlockRegistry Error:</strong> ' . esc_html($e->getMessage()) . '</p>';
+        }
+    }
+    
+    /**
+     * Check if block files exist
+     */
+    private static function check_block_files(): void {
+        $block_files = [
+            'BaseBlock.php',
+            'BlockRegistry.php',
+            'MovieMetadataBlock.php',
+            'TvSeriesMetadataBlock.php',
+            'DramaMetadataBlock.php',
+            'PeopleMetadataBlock.php',
+            'TvEpisodeMetadataBlock.php',
+            'DramaEpisodeMetadataBlock.php',
+            'SeasonMetadataBlock.php',
+            'VideoMetadataBlock.php',
+            'TaxonomyImageBlock.php',
+            'TaxonomyFaqsBlock.php',
+            'BlogPostsListBlock.php',
+            'TrendingContentBlock.php',
+            'TmdbSyncBlock.php',
+        ];
+        
+        $blocks_dir = TMU_INCLUDES_DIR . '/classes/Blocks/';
+        
+        echo '<ul>';
+        foreach ($block_files as $file) {
+            $file_path = $blocks_dir . $file;
+            $status = file_exists($file_path) ? '✅' : '❌';
+            echo "<li>{$status} {$file}</li>";
+        }
+        echo '</ul>';
+    }
+    
+    /**
+     * Check if block assets exist
+     */
+    private static function check_block_assets(): void {
+        $asset_files = [
+            'js/blocks-editor.js',
+            'css/blocks-editor.css',
+            'css/blocks.css',
+            'js/blocks.js',
+        ];
+        
+        $build_dir = TMU_THEME_DIR . '/assets/build/';
+        
+        echo '<ul>';
+        foreach ($asset_files as $file) {
+            $file_path = $build_dir . $file;
+            $status = file_exists($file_path) ? '✅' : '❌';
+            $url = TMU_THEME_URL . '/assets/build/' . $file;
+            echo "<li>{$status} {$file} (<a href='{$url}' target='_blank'>View</a>)</li>";
+        }
+        echo '</ul>';
+    }
+    
+    /**
+     * Check WordPress block registry
+     */
+    private static function check_wp_blocks(): void {
+        $registered_blocks = \WP_Block_Type_Registry::get_instance()->get_all_registered();
+        $tmu_blocks = array_filter($registered_blocks, function($block_name) {
+            return strpos($block_name, 'tmu/') === 0;
+        }, ARRAY_FILTER_USE_KEY);
+        
+        echo '<p><strong>WordPress Registered TMU Blocks:</strong></p>';
+        if (empty($tmu_blocks)) {
+            echo '<p>❌ No TMU blocks found in WordPress registry</p>';
+        } else {
+            echo '<ul>';
+            foreach ($tmu_blocks as $block_name => $block_type) {
+                echo "<li>✅ {$block_name}</li>";
+            }
+            echo '</ul>';
+        }
+        
+        echo '<p><strong>Block Categories:</strong></p>';
+        $categories = get_default_block_categories();
+        $tmu_category_found = false;
+        foreach ($categories as $category) {
+            if ($category['slug'] === 'tmu-blocks') {
+                $tmu_category_found = true;
+                break;
+            }
+        }
+        echo $tmu_category_found ? '<p>✅ TMU Blocks category found</p>' : '<p>❌ TMU Blocks category not found</p>';
+    }
+}

--- a/tmu-theme/includes/classes/ThemeCore.php
+++ b/tmu-theme/includes/classes/ThemeCore.php
@@ -123,11 +123,27 @@ class ThemeCore {
         
         // Load Step 07 - Custom Fields (Native WordPress)
         // Block system files - loaded conditionally if they exist
+        require_once TMU_INCLUDES_DIR . '/classes/Blocks/BaseBlock.php';
+        require_once TMU_INCLUDES_DIR . '/classes/Blocks/BlockRegistry.php';
+        require_once TMU_INCLUDES_DIR . '/classes/Blocks/MovieMetadataBlock.php';
+        require_once TMU_INCLUDES_DIR . '/classes/Blocks/TvSeriesMetadataBlock.php';
+        require_once TMU_INCLUDES_DIR . '/classes/Blocks/DramaMetadataBlock.php';
+        require_once TMU_INCLUDES_DIR . '/classes/Blocks/PeopleMetadataBlock.php';
+        require_once TMU_INCLUDES_DIR . '/classes/Blocks/TvEpisodeMetadataBlock.php';
+        require_once TMU_INCLUDES_DIR . '/classes/Blocks/DramaEpisodeMetadataBlock.php';
+        require_once TMU_INCLUDES_DIR . '/classes/Blocks/SeasonMetadataBlock.php';
+        require_once TMU_INCLUDES_DIR . '/classes/Blocks/VideoMetadataBlock.php';
+        require_once TMU_INCLUDES_DIR . '/classes/Blocks/TaxonomyImageBlock.php';
+        require_once TMU_INCLUDES_DIR . '/classes/Blocks/TaxonomyFaqsBlock.php';
+        require_once TMU_INCLUDES_DIR . '/classes/Blocks/BlogPostsListBlock.php';
+        require_once TMU_INCLUDES_DIR . '/classes/Blocks/TrendingContentBlock.php';
+        require_once TMU_INCLUDES_DIR . '/classes/Blocks/TmdbSyncBlock.php';
         
         // Load Step 08 - Admin UI 
         require_once TMU_INCLUDES_DIR . '/classes/Admin/AdminManager.php';
         require_once TMU_INCLUDES_DIR . '/classes/Admin/Columns/MovieColumns.php';
         require_once TMU_INCLUDES_DIR . '/classes/Admin/Actions/TMDBSync.php';
+        require_once TMU_INCLUDES_DIR . '/classes/Admin/BlocksDebug.php';
         
         // Load Step 11 - SEO and Schema Markup classes
         require_once TMU_INCLUDES_DIR . '/classes/SEO/SEOManager.php';
@@ -219,12 +235,13 @@ class ThemeCore {
         // Initialize Step 07 - Custom Fields
         $field_manager = Fields\FieldManager::getInstance();
         
-        // Initialize Step 07 - Custom Fields
-        // Block system - conditionally loaded if available
+        // Initialize Block system
+        Blocks\BlockRegistry::getInstance();
         
         // Initialize Step 08 - Admin UI and Meta Boxes
         if (is_admin()) {
             Admin\AdminManager::getInstance();
+            Admin\BlocksDebug::init();
         }
         
         // Initialize Step 11 - SEO and Schema Markup


### PR DESCRIPTION
Enable custom WordPress blocks by ensuring their files are loaded, the block registry is initialized, and necessary assets are present.

The custom blocks were created but not appearing in the WordPress editor because their PHP files were not being loaded in `ThemeCore.php`, the `BlockRegistry` was not initialized, and essential JavaScript/CSS build files were missing. This PR adds the necessary includes, initializes the block system, creates the missing asset files, and introduces a debug tool for block registration.